### PR TITLE
Allow any prefix to semver tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+- Allow any prefix to semver tag
+
 ## [1.0.0] - 2019-10-01
 - First stable release.
 

--- a/internal/pkg/local/local.go
+++ b/internal/pkg/local/local.go
@@ -26,7 +26,8 @@ func GetDetails(r *remote.Remote) error {
 	}
 
 	// remove v from version tag.
-	name := strings.Trim(tag, "v")
+	var re = regexp.MustCompile(".*([0-9]+.[0-9]+.[0-9]+)")
+	name := re.ReplaceAllString(tag, "$1")
 
 	r.Owner = repoName["owner"]
 	r.Repository = repoName["name"]
@@ -66,10 +67,10 @@ func getVersionTag() (string, error) {
 		return "", errors.New("environmental variable GITHUB_REF not defined")
 	}
 
-	regex := regexp.MustCompile("refs/tags/v?[0-9]+.[0-9]+.[0-9]+")
+	regex := regexp.MustCompile("refs/tags/.*[0-9]+.[0-9]+.[0-9]+")
 	if regex.MatchString(o) {
 		return strings.Split(o, "/")[2], nil
 	}
 
-	return "", errors.New("no matching tags found. expected to match regex 'v?[0-9]+.[0-9]+.[0-9]+'")
+	return "", errors.New("no matching tags found. expected to match regex '.*[0-9]+.[0-9]+.[0-9]+'")
 }


### PR DESCRIPTION
We have a use case for allowing prefixes other than `v` on an otherwise semver tag. This allows any (or no) prefix tag to work, as long as it ends in a semantic version.

I don't see any contributing guidelines so I didn't want to make an assumption about updating the version, but let me know if I should add a `[1.1.0]` as opposed to `[Unreleased]` (and update the docker label).