### PR TITLE
Update docs/examples: UNRELEASED

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -289,7 +289,7 @@ jobs:
         uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UNRELEASED: "true"
+          UNRELEASED: "update"
         with:
           args: linux-amd64
 ```
@@ -323,7 +323,7 @@ jobs:
         uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UNRELEASED: "true"
+          UNRELEASED: "update"
           UNRELEASED_TAG: future
         with:
           args: linux-amd64


### PR DESCRIPTION
Using "true" for UNRELEASED, I get this error:
![grafik](https://user-images.githubusercontent.com/53038537/126909601-22a62b58-d459-4f94-9a49-e2332e829cba.png)

using "update" it works flawless, would be nice to have that reflected in the examples as well :-)