### PR TITLE
Recover from transient network errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,11 @@
-# OS
 **/.DS_Store
-
-# IDE
 .vscode/
 **/__debug_bin
 **/debug.test
 .idea/
-
-# project
 coverage.txt
 /vendor/
 **/testFile*
-
 release/*
 !release/*.go
+api/

--- a/mocks/RepositoriesClient.go
+++ b/mocks/RepositoriesClient.go
@@ -71,6 +71,29 @@ func (_m *RepositoriesClient) DeleteRelease(_a0 context.Context, _a1 string, _a2
 	return r0, r1
 }
 
+// DeleteReleaseAsset provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *RepositoriesClient) DeleteReleaseAsset(_a0 context.Context, _a1 string, _a2 string, _a3 int64) (*github.Response, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
+
+	var r0 *github.Response
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) *github.Response); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetReleaseByTag provides a mock function with given fields: _a0, _a1, _a2, _a3
 func (_m *RepositoriesClient) GetReleaseByTag(_a0 context.Context, _a1 string, _a2 string, _a3 string) (*github.RepositoryRelease, *github.Response, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)

--- a/release/modal.go
+++ b/release/modal.go
@@ -48,6 +48,7 @@ type RepositoriesClient interface {
 	CreateRelease(context.Context, string, string, *github.RepositoryRelease) (*github.RepositoryRelease, *github.Response, error)
 	DeleteRelease(context.Context, string, string, int64) (*github.Response, error)
 	GetReleaseByTag(context.Context, string, string, string) (*github.RepositoryRelease, *github.Response, error)
+	DeleteReleaseAsset(context.Context, string, string, int64) (*github.Response, error)
 }
 
 type GitClient interface {


### PR DESCRIPTION
This should help workaround transient network issues (described in #61) by catching 502/422 HTTP errors during assets upload, deleting partially uploaded assets, and retrying.
