### PR TITLE
Introduce env vars for prefix and suffix body content surrounding Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `BODY_PREFIX` and `BODY_SUFFIX` to allow custom content before and after Changelog in Release body
+
 ## [6.0.0] - 2024-01-17
 
 :warning: GitHub Actions initiate a deprecation process for [Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ A **GitHub Action** for a **GitHub Release** creation with **Assets** and **Chan
     | `RELEASE_NAME_PREFIX`   | `*`               | ""                | Release title prefix                                                                                                       |
     | `RELEASE_NAME_SUFFIX`   | `*`               | ""                | Release title suffix                                                                                                       |
     | `UNRELEASED`            | `update`/`delete` | ""                | Set to `update` in order to allow deletion and recreation of the same release and its tag (intended to be used for `unreleased`/`latest` release only). Set to `delete` in order to delete a previously published `unreleased`/`latest` release.                                                                                     |
-    | `UNRELEASED_TAG`        | `latest`       | `*`               | Use a custom tag for `unreleased`/`latest` release (tag will be created/deleted automatically)                             |
+    | `UNRELEASED_TAG`        | `latest`          | `*`               | Use a custom tag for `unreleased`/`latest` release (tag will be created/deleted automatically)                             |
+    | `BODY_PREFIX`           | `*`               | ""                | Custom text to prepend before the changelog contents                                                                       |
+    | `BODY_SUFFIX`           | `*`               | ""                | Custom text to append after the changelog contents                                                                         |
 
     *Configuration is provided as environmental variables (strings), so do not forget to enclose boolean values with quotes*
 

--- a/config.go
+++ b/config.go
@@ -25,6 +25,8 @@ type Configuration struct {
 	ReleaseNamePrefix   string
 	ReleaseNameSuffix   string
 	ChangelogFile       string
+	BodyPrefix          string
+	BodySuffix          string
 }
 
 // GetConfig sets validated Release/Changelog configuration and returns github.com Token
@@ -75,6 +77,9 @@ func GetConfig(fs afero.Fs) (*Configuration, error) {
 		conf.IgnoreChangelog = true
 	}
 
+	conf.BodyPrefix = os.Getenv("BODY_PREFIX")
+	conf.BodySuffix = os.Getenv("BODY_SUFFIX")
+
 	// NOTE: deprecation warnings
 	if os.Getenv("RELEASE_NAME_POSTFIX") != "" {
 		log.Fatalf(`'RELEASE_NAME_POSTFIX' was deprecated.
@@ -87,6 +92,20 @@ func GetConfig(fs afero.Fs) (*Configuration, error) {
 	}
 
 	return conf, nil
+}
+
+func (c *Configuration) GetBody(fs afero.Fs, rel *release.Release) (string, error) {
+	body := c.BodyPrefix
+	if c.ChangelogFile != "" {
+		changelogContents, err := c.GetChangelog(fs, rel)
+		if err != nil {
+			return "", errors.Wrap(err, "error formatting release body")
+		}
+		body += changelogContents
+	}
+	body += c.BodySuffix
+
+	return body, nil
 }
 
 func (c *Configuration) GetChangelog(fs afero.Fs, rel *release.Release) (string, error) {

--- a/main.go
+++ b/main.go
@@ -66,11 +66,9 @@ func main() {
 		log.Fatal(errors.Wrap(err, "error fetching release configuration"))
 	}
 
-	if conf.ChangelogFile != "" {
-		rel.Changelog, err = conf.GetChangelog(fs, rel)
-		if err != nil {
-			log.Fatal(errors.Wrap(err, "error reading changelog"))
-		}
+	rel.Body, err = conf.GetBody(fs, rel)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "error getting release body"))
 	}
 
 	cli, err := Login(os.Getenv("GITHUB_TOKEN"))

--- a/release/modal.go
+++ b/release/modal.go
@@ -24,7 +24,7 @@ type Release struct {
 	Draft      bool
 	PreRelease bool
 	Assets     *[]Asset
-	Changelog  string
+	Body       string
 }
 
 type Slug struct {

--- a/release/release.go
+++ b/release/release.go
@@ -141,7 +141,7 @@ func (r *Release) Publish(cli RepositoriesClient) error {
 			Name:            &r.Name,
 			TagName:         &r.Reference.Tag,
 			TargetCommitish: &r.Reference.CommitHash,
-			Body:            &r.Changelog,
+			Body:            &r.Body,
 			Draft:           &r.Draft,
 			Prerelease:      &r.PreRelease,
 		},

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -877,7 +877,7 @@ func TestPublish(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: nil,
@@ -910,7 +910,7 @@ func TestPublish(t *testing.T) {
 						Path: "file2",
 					},
 				},
-				Changelog: "changelog",
+				Body: "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: &github.RepositoryRelease{
@@ -936,7 +936,7 @@ func TestPublish(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: nil,
@@ -964,7 +964,7 @@ func TestPublish(t *testing.T) {
 						Path: "file1",
 					},
 				},
-				Changelog: "changelog",
+				Body: "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: &github.RepositoryRelease{
@@ -1007,7 +1007,7 @@ main:
 				Name:            &test.Release.Name,
 				TagName:         &test.Release.Reference.Tag,
 				TargetCommitish: &test.Release.Reference.CommitHash,
-				Body:            &test.Release.Changelog,
+				Body:            &test.Release.Body,
 				Draft:           &test.Release.Draft,
 				Prerelease:      &test.Release.PreRelease,
 			}).Return(test.CreateReleaseMock.Output, nil, test.CreateReleaseMock.Error).Once()
@@ -1086,7 +1086,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1118,7 +1118,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: nil,
@@ -1144,7 +1144,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1173,7 +1173,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1202,7 +1202,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1288,7 +1288,7 @@ func TestUpdateUnreleasedTag(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateRefMockError: nil,
 			ExpectedError:      "",
@@ -1308,7 +1308,7 @@ func TestUpdateUnreleasedTag(t *testing.T) {
 				Draft:      false,
 				PreRelease: false,
 				Assets:     nil,
-				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateRefMockError: errors.New("reason"),
 			ExpectedError:      "reason",


### PR DESCRIPTION
Adds `BODY_PREFIX` and `BODY_SUFFIX` optional environment variable configurations to enable augmenting release body contents around the Changlog entries.

For example, I want a suffix after my Changlog in each release explaining the various artifacts produced in the release (fat jar vs online download)

---

An alternative implementation might be a single variable for eg `BODY_FORMAT`, which could used something like `fmt.Sprintf(rel.BodyFormat, rel.Changelog)`