### PR TITLE
Add release body templating support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ A **GitHub Action** for a **GitHub Release** creation with **Assets** and **Chan
     | `RELEASE_NAME`          | `*`               | ""                | Complete release title (should not be combined with `RELEASE_NAME_PREFIX` and `RELEASE_NAME_SUFFIX`)                       |
     | `RELEASE_NAME_PREFIX`   | `*`               | ""                | Release title prefix                                                                                                       |
     | `RELEASE_NAME_SUFFIX`   | `*`               | ""                | Release title suffix                                                                                                       |
+    | `BODY_TEMPLATE`        | `*`               | ""                | Release body template. Use `{{.Changelog}}` to inject changelog
+                                   |
     | `UNRELEASED`            | `update`/`delete` | ""                | Set to `update` in order to allow deletion and recreation of the same release and its tag (intended to be used for `unreleased`/`latest` release only). Set to `delete` in order to delete a previously published `unreleased`/`latest` release.                                                                                     |
     | `UNRELEASED_TAG`        | `latest`       | `*`               | Use a custom tag for `unreleased`/`latest` release (tag will be created/deleted automatically)                             |
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path"
@@ -12,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"text/template"
 )
 
 // Configuration is a git-release settings struct
@@ -24,6 +26,7 @@ type Configuration struct {
 	ReleaseName         string
 	ReleaseNamePrefix   string
 	ReleaseNameSuffix   string
+	BodyTemplate        string
 	ChangelogFile       string
 }
 
@@ -50,6 +53,7 @@ func GetConfig(fs afero.Fs) (*Configuration, error) {
 	conf.ReleaseName = os.Getenv("RELEASE_NAME")
 	conf.ReleaseNamePrefix = os.Getenv("RELEASE_NAME_PREFIX")
 	conf.ReleaseNameSuffix = os.Getenv("RELEASE_NAME_SUFFIX")
+	conf.BodyTemplate = os.Getenv("BODY_TEMPLATE")
 
 	if conf.ReleaseName != "" && ((conf.ReleaseNamePrefix != "" && conf.ReleaseNameSuffix != "") || (conf.ReleaseNamePrefix != "" || conf.ReleaseNameSuffix != "")) {
 		return nil, errors.New("both RELEASE_NAME and RELEASE_NAME_PREFIX / RELEASE_NAME_SUFFIX are set (expected RELEASE_NAME or combination/one of RELEASE_NAME_PREFIX and RELEASE_NAME_SUFFIX)")
@@ -127,4 +131,31 @@ func (c *Configuration) GetChangelog(fs afero.Fs, rel *release.Release) (string,
 
 	log.Warn(msg)
 	return "", nil
+}
+
+func (c *Configuration) GetBody(fs afero.Fs, rel *release.Release) (string, error) {
+	var changelog string
+	var err error
+
+	if c.ChangelogFile != "" {
+		changelog, err = c.GetChangelog(fs, rel)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if c.BodyTemplate == "" {
+		return changelog, nil
+	}
+
+	tmpl, err := template.New("body").Parse(c.BodyTemplate)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	data := struct{ Changelog string }{Changelog: changelog}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/config.go
+++ b/config.go
@@ -140,7 +140,7 @@ func (c *Configuration) GetBody(fs afero.Fs, rel *release.Release) (string, erro
 	if c.ChangelogFile != "" {
 		changelog, err = c.GetChangelog(fs, rel)
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "error getting changelog")
 		}
 	}
 
@@ -150,12 +150,12 @@ func (c *Configuration) GetBody(fs afero.Fs, rel *release.Release) (string, erro
 
 	tmpl, err := template.New("body").Parse(c.BodyTemplate)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "error parsing body template")
 	}
 	var buf bytes.Buffer
 	data := struct{ Changelog string }{Changelog: changelog}
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "error executing body template")
 	}
 	return buf.String(), nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -10,13 +10,27 @@ import (
 )
 
 func init() {
-	os.Setenv("GITHUB_REPOSITORY", "owner/repo")
-	os.Setenv("GITHUB_TOKEN", "token")
-	os.Setenv("GITHUB_WORKSPACE", ".")
-	os.Setenv("GITHUB_API_URL", "https://api.github.com")
-	os.Setenv("GITHUB_SERVER_URL", "https://github.com")
-	os.Setenv("GITHUB_REF", "refs/tags/1.0.0")
-	os.Setenv("GITHUB_SHA", "deadbeef")
+	if err := os.Setenv("GITHUB_REPOSITORY", "owner/repo"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_TOKEN", "token"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_WORKSPACE", "."); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_API_URL", "https://api.github.com"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_SERVER_URL", "https://github.com"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_REF", "refs/tags/1.0.0"); err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("GITHUB_SHA", "deadbeef"); err != nil {
+		panic(err)
+	}
 }
 
 func TestGetBody(t *testing.T) {
@@ -29,7 +43,7 @@ func TestGetBody(t *testing.T) {
 ## [1.0.0] - 2024-01-01
 ### Added
 - Something`
-	afero.WriteFile(fs, "CHANGELOG.md", []byte(changelog), 0644)
+	a.NoError(afero.WriteFile(fs, "CHANGELOG.md", []byte(changelog), 0644))
 
 	conf := &Configuration{ChangelogFile: "CHANGELOG.md", BodyTemplate: "Header\n{{.Changelog}}\nFooter"}
 	rel := &release.Release{Reference: &release.Reference{Version: "1.0.0"}}

--- a/config_test.go
+++ b/config_test.go
@@ -54,13 +54,13 @@ func TestGetBody(t *testing.T) {
 	a.Equal(expected, body)
 }
 
-func TestGetBodyMissingChangelog(t *testing.T) {
+func TestGetBodyTemplateError(t *testing.T) {
 	a := assert.New(t)
 	fs := afero.NewMemMapFs()
-	conf := &Configuration{ChangelogFile: "", BodyTemplate: "Header\n{{.Changelog}}\nFooter"}
+	a.NoError(afero.WriteFile(fs, "CHANGELOG.md", []byte(""), 0644))
+	conf := &Configuration{ChangelogFile: "CHANGELOG.md", BodyTemplate: "{{.Changelog"}
 	rel := &release.Release{Reference: &release.Reference{Version: "1.0.0"}}
 
-	body, err := conf.GetBody(fs, rel)
-	a.NoError(err)
-	a.Equal("Header\n\nFooter", body)
+	_, err := conf.GetBody(fs, rel)
+	a.Error(err)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"git-release/release"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	os.Setenv("GITHUB_REPOSITORY", "owner/repo")
+	os.Setenv("GITHUB_TOKEN", "token")
+	os.Setenv("GITHUB_WORKSPACE", ".")
+	os.Setenv("GITHUB_API_URL", "https://api.github.com")
+	os.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	os.Setenv("GITHUB_REF", "refs/tags/1.0.0")
+	os.Setenv("GITHUB_SHA", "deadbeef")
+}
+
+func TestGetBody(t *testing.T) {
+	a := assert.New(t)
+	fs := afero.NewMemMapFs()
+
+	// prepare changelog file
+	changelog := `# Changelog
+
+## [1.0.0] - 2024-01-01
+### Added
+- Something`
+	afero.WriteFile(fs, "CHANGELOG.md", []byte(changelog), 0644)
+
+	conf := &Configuration{ChangelogFile: "CHANGELOG.md", BodyTemplate: "Header\n{{.Changelog}}\nFooter"}
+	rel := &release.Release{Reference: &release.Reference{Version: "1.0.0"}}
+
+	body, err := conf.GetBody(fs, rel)
+	a.NoError(err)
+	expected := "Header\n### Added\n\n- Something\n\nFooter"
+	a.Equal(expected, body)
+}
+
+func TestGetBodyMissingChangelog(t *testing.T) {
+	a := assert.New(t)
+	fs := afero.NewMemMapFs()
+	conf := &Configuration{ChangelogFile: "", BodyTemplate: "Header\n{{.Changelog}}\nFooter"}
+	rel := &release.Release{Reference: &release.Reference{Version: "1.0.0"}}
+
+	body, err := conf.GetBody(fs, rel)
+	a.NoError(err)
+	a.Equal("Header\n\nFooter", body)
+}

--- a/docs/example.md
+++ b/docs/example.md
@@ -192,6 +192,36 @@ jobs:
 
 </details>
 
+## Release body template
+
+<details><summary>Workflow</summary>
+
+```yaml
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Release
+        uses: docker://antonyurchenko/git-release:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY_TEMPLATE: "Header\n{{.Changelog}}\nFooter"
+        with:
+          args: build/*.zip
+```
+
+</details>
+
 ## Asset Filename Pattern Matching
 
 ![PIC](images/release.png)

--- a/main.go
+++ b/main.go
@@ -73,6 +73,11 @@ func main() {
 		}
 	}
 
+	rel.Body, err = conf.GetBody(fs, rel)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "error creating release body"))
+	}
+
 	cli, err := Login(os.Getenv("GITHUB_TOKEN"))
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "login error"))

--- a/release/modal.go
+++ b/release/modal.go
@@ -25,6 +25,7 @@ type Release struct {
 	PreRelease bool
 	Assets     *[]Asset
 	Changelog  string
+	Body       string
 }
 
 type Slug struct {

--- a/release/release.go
+++ b/release/release.go
@@ -141,7 +141,7 @@ func (r *Release) Publish(cli RepositoriesClient) error {
 			Name:            &r.Name,
 			TagName:         &r.Reference.Tag,
 			TargetCommitish: &r.Reference.CommitHash,
-			Body:            &r.Changelog,
+			Body:            &r.Body,
 			Draft:           &r.Draft,
 			Prerelease:      &r.PreRelease,
 		},

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -878,6 +878,7 @@ func TestPublish(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: nil,
@@ -911,6 +912,7 @@ func TestPublish(t *testing.T) {
 					},
 				},
 				Changelog: "changelog",
+				Body:      "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: &github.RepositoryRelease{
@@ -937,6 +939,7 @@ func TestPublish(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: nil,
@@ -965,6 +968,7 @@ func TestPublish(t *testing.T) {
 					},
 				},
 				Changelog: "changelog",
+				Body:      "changelog",
 			},
 			CreateReleaseMock: createReleaseMock{
 				Output: &github.RepositoryRelease{
@@ -1007,7 +1011,7 @@ main:
 				Name:            &test.Release.Name,
 				TagName:         &test.Release.Reference.Tag,
 				TargetCommitish: &test.Release.Reference.CommitHash,
-				Body:            &test.Release.Changelog,
+				Body:            &test.Release.Body,
 				Draft:           &test.Release.Draft,
 				Prerelease:      &test.Release.PreRelease,
 			}).Return(test.CreateReleaseMock.Output, nil, test.CreateReleaseMock.Error).Once()
@@ -1087,6 +1091,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1119,6 +1124,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: nil,
@@ -1145,6 +1151,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1174,6 +1181,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{
@@ -1203,6 +1211,7 @@ func TestDeleteUnreleased(t *testing.T) {
 				PreRelease: false,
 				Assets:     nil,
 				Changelog:  "changelog",
+				Body:       "changelog",
 			},
 			GetReleaseByTagMock: getReleaseByTagMock{
 				Output: &github.RepositoryRelease{


### PR DESCRIPTION
## Summary
- add `BodyTemplate` configuration and new `GetBody` helper
- wire up release body creation in main
- support templated release bodies in `release` package
- document `BODY_TEMPLATE` and show example usage
- test new body logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6841efe5834083318d93d43cd7d881ed